### PR TITLE
DEEP-370- Creating the Welsh Screens for the Extension Service

### DIFF
--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -1,0 +1,6 @@
+{
+  "continue": "Lorem",
+  "back": "ipsum",
+  "sign_out": "dolor sit",
+  "manage_account": "amet consectetur"
+}

--- a/locales/cy/extension-confirmation.json
+++ b/locales/cy/extension-confirmation.json
@@ -1,0 +1,18 @@
+{
+  "extension_confirmation_title": "Lorem ipsum dolor sit amet",
+  "extension_confirmation_deadline_html": "consectetur adipiscing elit. Cras",
+  "extension_confirmation_company_name": "Duis massa",
+  "extension_confirmation_company_number": "commodo eu ultrice",
+  "extension_confirmation_psc_name": "Nullam lectus",
+  "extension_confirmation_reference_number": "sagittis vel tempor sit amet",
+  "extension_confirmation_link_1": "Duis massa urna, scelerisque vel enim",
+  "extension_confirmation_link_2": "interdum finibus mauris",
+  "extension_confirmation_links_info": "Praesent scelerisque aliquam erat sit amet suscipit:",
+  "extension_confirmation_links_title": "Nullam lectus felis, commodo?",
+  "extension_confirmation_another_extension_info": "ultrices et, hendrerit eget orci. Mauris gravida urna a aliquet lobortis. Integer volutpat, sapien eu ultrices venenatis",
+  "extension_confirmation_another_extension_title": "Proin quis quam pellentesque, efficitur ipsum sit amet, porttitor sapien",
+  "extension_confirmation_first_info": "Sed vitae gravida sapien. Nunc consectetur nisl sed iaculis suscipit proin ultrice",
+  "extension_confirmation_second_info_line1": "Cras et ex at tortor interdum mattis",
+  "extension_confirmation_second_info_line2": "Maecenas magna urna, sagittis eu dictum congue, iaculis"
+
+}

--- a/locales/cy/extension-info.json
+++ b/locales/cy/extension-info.json
@@ -1,3 +1,9 @@
 {
-    "extension_info_title": ""
+    "extension_info_title": "Lorem ipsum dolor",
+    "extension_info_born_caption": "consectetur",
+    "extension_info_request_extension_description_1": "adipiscing elit cras, ",
+    "extension_info_request_extension_description_2": " praesent scelerisque aliquam erat sit amet suscipit",
+    "extension_info_submit_request_description": "Ultrices et, hendrerit eget orci. Mauris gravida urna a aliquet lobortis. ",
+    "extension_info_role_description_1" : "Proin quis quam pellentesque, efficitur ipsum sit amet ",
+    "extension_info_role_description_2" : ", consectetur nisl sed iaculis suscipit proin ultrice."
 }

--- a/locales/cy/extension-refused.json
+++ b/locales/cy/extension-refused.json
@@ -1,0 +1,11 @@
+{
+  "extension_refused_title": "Lorem ipsum dolor",
+  "extension_refused_born_caption": "Consectetur",
+  "extension_refused_request_extension_description_1": "Praesent scelerisque aliquam erat sit amet suscipit:",
+  "extension_refused_request_extension_description_2": " sagittis vel tempor sit amet",
+  "extension_refused_request_extension_description_3": " interdum finibus mauris",
+  "extension_refused_request_description": "hendrerit eget orci mauris gravida urna a aliquet lobortis. ",
+  "extension_refused_warning_description" : "Ultrices et, hendrerit eget orci mauris gravida urna a aliquet lobortis integer volutpat, sapien eu ultrices venenatis",
+  "extension_refused_request_guidance_1" : "Cras et ex at ",
+  "extension_refused_request_guidance_2" : "tortor interdum mattis."
+}

--- a/locales/cy/layout.json
+++ b/locales/cy/layout.json
@@ -10,5 +10,11 @@
   "footer_cookies": "Consectetur",
   "footer_contact_us": "Iaculis suscipit",
   "footer_developers": "Proin",
-  "footer_accessibility_statement": "Efficitur ipsum"
+  "footer_accessibility_statement": "Efficitur ipsum",
+
+   "global_footer_ogl_v3": "Drwydded Llywodraeth Agored v3.0",
+    "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/",
+    "global_footer_licence_p1": "Mae'r holl gynnwys ar gael o dan y ",
+    "global_footer_licence_p2": ", ac eithrio lle nodir yn wahanol",
+    "global_footer_crown_copyright": "© Hawlfraint y Goron"
 }

--- a/locales/cy/layout.json
+++ b/locales/cy/layout.json
@@ -12,9 +12,9 @@
   "footer_developers": "Proin",
   "footer_accessibility_statement": "Efficitur ipsum",
 
-   "global_footer_ogl_v3": "Drwydded Llywodraeth Agored v3.0",
-    "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/",
-    "global_footer_licence_p1": "Mae'r holl gynnwys ar gael o dan y ",
-    "global_footer_licence_p2": ", ac eithrio lle nodir yn wahanol",
-    "global_footer_crown_copyright": "© Hawlfraint y Goron"
+  "global_footer_ogl_v3": "Drwydded Llywodraeth Agored v3.0",
+  "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/",
+  "global_footer_licence_p1": "Mae'r holl gynnwys ar gael o dan y ",
+  "global_footer_licence_p2": ", ac eithrio lle nodir yn wahanol",
+  "global_footer_crown_copyright": "© Hawlfraint y Goron"
 }

--- a/locales/cy/layout.json
+++ b/locales/cy/layout.json
@@ -1,0 +1,14 @@
+{
+  "service_name": "Ultrices et, hendrerit eget orci. Mauris gravida urna a aliquet lobortis.",
+
+  "phase_banner_new_service": "praesent scelerisque aliquam erat - ",
+  "phase_banner_feedback_link": "Lorem ipsum",
+  "phase_banner_help_improve": " sit amet suscipit.",
+  "phase_banner_tag": "Adipiscing",
+
+  "footer_policies": "Lorem",
+  "footer_cookies": "Consectetur",
+  "footer_contact_us": "Iaculis suscipit",
+  "footer_developers": "Proin",
+  "footer_accessibility_statement": "Efficitur ipsum"
+}

--- a/locales/cy/reason-for-extension.json
+++ b/locales/cy/reason-for-extension.json
@@ -1,0 +1,11 @@
+{
+  "reason_for_extension_born_caption": "Lorem ipsum",
+  "reason_for_extension_title": "Lorem ipsum dolor sit amet",
+  "reason_for_extension_1": "Duis massa urna, scelerisque vel enim interdum finibus mauris agittis vel tempor sit amet",
+  "reason_for_extension_2": "ultrices et, hendrerit eget orci. Mauris gravida urna a aliquet lobortis.",
+  "reason_for_extension_3": "Etiam id nisl porttitor, cursus lacus ut, posuere metus. Nunc at dolor in lectus vehicula maximus. Maecenas laoreet nulla quis ipsum sagittis malesuada",
+  "reason_for_extension_4": "Tendrerit eget orci. Mauris gravida urna a aliquet lobortis. Integer volutpat, sapien eu ultrices venenatis",
+  "reason_for_extension_5": "Sed vitae gravida sapien. Nunc consectetur nisl sed iaculis suscipit proin ultrice",
+  "reason_for_extension_6": "Praesent scelerisque aliquam erat sit amet suscipit ",
+  "reason_for_extension_error_message": "Nunc consectetur nisl sed iaculis suscipit proin ultrice "
+}

--- a/locales/en/layout.json
+++ b/locales/en/layout.json
@@ -10,5 +10,11 @@
     "footer_cookies": "Cookies",
     "footer_contact_us": "Contact us",
     "footer_developers": "Developers",
-    "footer_accessibility_statement": "Accessibility Statement"
+    "footer_accessibility_statement": "Accessibility Statement",
+
+    "global_footer_ogl_v3": "Open Government Licence v3.0",
+    "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+    "global_footer_licence_p1": "All content is available under the ",
+    "global_footer_licence_p2": ", except where otherwise stated",
+    "global_footer_crown_copyright": "© Crown copyright"
 }

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -1,6 +1,7 @@
 {# Extends the Companies House Page Template: https://github.com/companieshouse/ch-node-utils/blob/2.0.0/docs/page-template.md #}
 {% extends "ch-node-utils/templates/layouts/template.njk" %}
-
+{% import "ch-node-utils/templates/add-lang-to-url.njk" as lang2url %}
+{% from "ch-node-utils/templates/navbar.njk" import addNavbar %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
@@ -13,37 +14,35 @@
   {% include "partials/__meta_header.njk" %}
 {% endblock %}
 
-{% block bodyStart %}
-  {# {% include "partials/cookie_consent_banner.njk" %} #}
+{% block header %}
+  {% include "partials/__header.njk" %}
 {% endblock %}
 
+{% block bodyStart %}
+  {# {% include "partials/cookie_consent_banner.njk" %} #}
 {% block skipLink %}
   {{ govukSkipLink({
     text: "Skip to main content",
     href: "#" + mainContentId
   }) }}
-{% endblock %}
-
-{% block header %}
-  {% include "partials/__header.njk" %}
+  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}
   {% include "partials/phase-banner.njk" %}
   {% include "partials/nav/top.njk" %}
-
   {% if backURL %}
     {{ govukBackLink({
-    href: backURL,
+    href: backURL + "?lang=" +lang,
     text: i18n.back
   }) }}
   {% endif %}
-  {% include "partials/language-toggle.njk" %}
+   {% include "ch-node-utils/templates/locales-banner.njk" %}
 {% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" id="{{ mainContentId }}">
+  <div class="govuk-grid-column-{{ gridColumnClass | default('two-thirds') }}" id="{{ mainContentId }}">
       {% include "partials/error_summary.njk" %}
       {% block main_content %}{% endblock %}
     </div>

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -2,7 +2,6 @@
 {% extends "ch-node-utils/templates/layouts/template.njk" %}
 {% import "ch-node-utils/templates/add-lang-to-url.njk" as lang2url %}
 {% from "ch-node-utils/templates/navbar.njk" import addNavbar %}
-{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set mainContentId = "main-page-content" %}
@@ -20,12 +19,6 @@
 
 {% block bodyStart %}
   {# {% include "partials/cookie_consent_banner.njk" %} #}
-{% block skipLink %}
-  {{ govukSkipLink({
-    text: "Skip to main content",
-    href: "#" + mainContentId
-  }) }}
-  {% endblock %}
 {% endblock %}
 
 {% block beforeContent %}

--- a/src/views/layouts/shell.njk
+++ b/src/views/layouts/shell.njk
@@ -1,5 +1,7 @@
 {# Extends the Companies House Page Template: https://github.com/companieshouse/ch-node-utils/blob/2.0.0/docs/page-template.md #}
 {% extends "ch-node-utils/templates/layouts/template.njk" %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
+{% import "ch-node-utils/templates/add-lang-to-url.njk" as lang2url %}
 
 {% block pageTitle %}{{ title }}{% endblock %}
 
@@ -12,8 +14,27 @@
   {% include "partials/__header.njk" %}
 {% endblock %}
 
+{% block bodyStart %}
+{% block skipLink %}
+  {{ govukSkipLink({
+    text: "Skip to main content",
+    href: "#" + mainContentId
+  }) }}
+  {% endblock %}
+  {% endblock %}
+
+{% block beforeContent %}
+   {% include "ch-node-utils/templates/locales-banner.njk" %}
+{% endblock %}
+
+
 {% block content %}
-    {% block main_content %}{% endblock %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-{{ gridColumnClass | default('two-thirds') }}" id="{{ mainContentId }}">
+      {% include "partials/error_summary.njk" %}
+      {% block main_content %}{% endblock %}
+    </div>
+  </div>
 {% endblock %}
 
 {% block footer %}

--- a/src/views/layouts/shell.njk
+++ b/src/views/layouts/shell.njk
@@ -1,6 +1,5 @@
 {# Extends the Companies House Page Template: https://github.com/companieshouse/ch-node-utils/blob/2.0.0/docs/page-template.md #}
 {% extends "ch-node-utils/templates/layouts/template.njk" %}
-{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% import "ch-node-utils/templates/add-lang-to-url.njk" as lang2url %}
 
 {% block pageTitle %}{{ title }}{% endblock %}
@@ -15,12 +14,6 @@
 {% endblock %}
 
 {% block bodyStart %}
-{% block skipLink %}
-  {{ govukSkipLink({
-    text: "Skip to main content",
-    href: "#" + mainContentId
-  }) }}
-  {% endblock %}
   {% endblock %}
 
 {% block beforeContent %}

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -1,5 +1,13 @@
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
 
+{%- set licenceHtml -%}
+<p class="govuk-footer__licence-description">{{ i18n.global_footer_licence_p1 }}
+    <a class="govuk-footer__link" target="_blank" rel="noopener noreferrer"
+  href="{{ i18n.global_footer_ogl_v3_url }}">{{ i18n.global_footer_ogl_v3 }}</a>
+    {{ i18n.global_footer_licence_p2 }}
+</p>
+{% endset %}
+
 {{ govukFooter({
   meta: {
     items: [
@@ -24,5 +32,11 @@
         text: i18n.footer_accessibility_statement 
       }
     ]
+  },
+    contentLicence: {
+    html: licenceHtml
+  },
+  copyright: {
+     text: i18n.global_footer_crown_copyright
   }
 }) }}

--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -1,5 +1,7 @@
 <link href="{{ cdnUrlCss }}/app.min.css" media="all" rel="stylesheet" type="text/css" />
 <link href="{{ cdnHost }}/stylesheets/ch.gov.uk.css" rel="stylesheet"/>
+<link href="{{ cdnHost }}/stylesheets/services/presenter-account/application.css" rel="stylesheet"/>
+<link href="{{ cdnHost }}/stylesheets/extensions/languages-nav.css" rel="stylesheet"/>
 <script>
     var page = page || {};
 </script>

--- a/src/views/partials/language-toggle.njk
+++ b/src/views/partials/language-toggle.njk
@@ -1,3 +1,0 @@
-<div style="text-align: right;">
-    <span style="padding-right: 20px;">English | <a href="#">Cymraeg</a></span>
-</div>

--- a/src/views/router_views/extension-info/extension-info.njk
+++ b/src/views/router_views/extension-info/extension-info.njk
@@ -14,7 +14,7 @@
 
 {{ govukButton({
   text: i18n.continue,
-  href: "/psc-extensions/reason-for-extension"
+  href: "/psc-extensions/reason-for-extension" + "?lang=" +lang 
 }) }}
 
 {% endblock %}

--- a/src/views/router_views/reason-for-extension/reason-for-extension.njk
+++ b/src/views/router_views/reason-for-extension/reason-for-extension.njk
@@ -61,7 +61,7 @@
                   {% endif %}
              {{ govukButton({
                 text: i18n.continue,
-                href: "/psc-extensions/extension-confirmation"
+                href: "/psc-extensions/extension-confirmation" + "?lang=" +lang 
              }) }}
     </form>
 

--- a/test/src/components.test.ts
+++ b/test/src/components.test.ts
@@ -1,0 +1,66 @@
+import { HttpStatusCode } from "axios";
+import mocks from "../mocks/all.middleware.mock";
+import app from "../../src/app";
+import * as cheerio from "cheerio";
+import request from "supertest";
+
+const router = request(app);
+
+const url = "/psc-extensions/extension-info";
+
+describe("GET extension info router and retrieve components such as footer links for both english or welsh depending on selected language", () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should check session and user auth before returning the page", async () => {
+        await router.get(url);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    });
+    it("should render the footer with the expected links in English when user has selected 'English' link", async () => {
+        const resp = await request(app).get(`/psc-extensions/extension-info?lang=en`);
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+
+        const expectedLinks = [
+            { href: "https://resources.companieshouse.gov.uk/serviceInformation.shtml", text: "Policies" },
+            { href: "http://chsurl.co/help/cookies", text: "Cookies" },
+            { href: "https://www.gov.uk/government/organisations/companies-house#org-contacts", text: "Contact us" },
+            { href: "https://developer.company-information.service.gov.uk/", text: "Developers" },
+            { href: "http://chsurl.co/help/accessibility-statement", text: "Accessibility Statement" }
+        ];
+
+        const footerLinks = $(".govuk-footer__inline-list-item a");
+        expect(footerLinks.length).toBe(expectedLinks.length);
+
+        expectedLinks.forEach((link, i) => {
+            expect(footerLinks.eq(i).attr("href")).toBe(link.href);
+            expect(footerLinks.eq(i).text().trim()).toBe(link.text);
+        });
+    });
+
+    it("should render the footer with the expected links in Welsh when user has selected 'Cymraeg' link", async () => {
+        const resp = await request(app).get(`/psc-extensions/extension-info?lang=cy`);
+        expect(resp.status).toBe(HttpStatusCode.Ok);
+        const $ = cheerio.load(resp.text);
+
+        const expectedLinks = [
+            { href: "https://resources.companieshouse.gov.uk/serviceInformation.shtml", text: "Lorem" },
+            { href: "http://chsurl.co/help/cookies", text: "Consectetur" },
+            { href: "https://www.gov.uk/government/organisations/companies-house#org-contacts", text: "Iaculis suscipit" },
+            { href: "https://developer.company-information.service.gov.uk/", text: "Proin" },
+            { href: "http://chsurl.co/help/accessibility-statement", text: "Efficitur ipsum" }
+        ];
+
+        const footerLinks = $(".govuk-footer__inline-list-item a");
+        expect(footerLinks.length).toBe(expectedLinks.length);
+
+        expectedLinks.forEach((link, i) => {
+            expect(footerLinks.eq(i).attr("href")).toBe(link.href);
+            expect(footerLinks.eq(i).text().trim()).toBe(link.text);
+        });
+    });
+
+});


### PR DESCRIPTION
**Jira ticket**: 
[DEEP-370](https://companieshouse.atlassian.net/browse/DEEP-370)
## Brief description of the change(s)

- For each screen in the Extension service, we have created the corresponding screen with the Welsh content.
- Welsh functionality implementation with welsh json files.
- Language included in the URL.
- Selected language continues to next pages.
- Test added to show evidence of welsh and english functionality working on common components such as footer links.

## Working example
>

https://github.com/user-attachments/assets/16349bd1-7f3d-433e-9793-b98dc7be4739


> Use screenshots or logs to show what your changes do.

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [x] Added/updated logging appropriately.
- [x] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.


[DEEP-370]: https://companieshouse.atlassian.net/browse/DEEP-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ