### PR TITLE
DEEP-460-Successful First Request Screen Banner size

### DIFF
--- a/src/views/router_views/extension-confirmation/extension-confirmation.njk
+++ b/src/views/router_views/extension-confirmation/extension-confirmation.njk
@@ -12,8 +12,6 @@
 {% endset %}
 
 {% block main_content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
   {{ govukPanel({
   titleText: i18n.extension_confirmation_title,
   html: panel
@@ -71,8 +69,5 @@
   <li><a href="/persons-with-significant-control-verification/confirm-company" class="govuk-link">{{i18n.extension_confirmation_link_2}}</a>.</li>
    <li><a href="/persons-with-significant-control-verification/company-number" class="govuk-link">{{i18n.extension_confirmation_link_1}}</a>.</li>
 </ul>
-
-  </div>
-</div>
 
 {% endblock %}


### PR DESCRIPTION
**Jira ticket**: 
https://companieshouse.atlassian.net/browse/DEEP-460
## Brief description of the change(s)

- Fixing the banner issue on the confirmation screen. This occurred when I changed {% block content %} to {% block main_content %} on the extension-confirmation.njk to solve an accessibility issue - https://github.com/companieshouse/psc-extensions-web/pull/38.

- block main_content doesn't need the additional divs surrounding it. 

## Working example
>
<img width="1385" height="997" alt="image" src="https://github.com/user-attachments/assets/98ff6840-0792-49b3-a303-46ab4fb0884c" />

> Use screenshots or logs to show what your changes do.

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [ ] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
