### PR TITLE
feat(deep-367-362): integrate PSC extensions web with psc-extensions-api backend

### DIFF
--- a/src/lib/utils/api.client.ts
+++ b/src/lib/utils/api.client.ts
@@ -1,0 +1,10 @@
+import {ApiClient, createApiClient} from "@companieshouse/api-sdk-node";
+import {Session} from "express-session";
+
+export const createOAuthApiClient = (session: Session): ApiClient => {
+    const accessToken = session?.data?.oauth2_nonce;
+    if (!accessToken) {
+        throw new Error("No access token found in session");
+    }
+    return createApiClient(undefined, accessToken);
+};

--- a/src/routers/handlers/new-submission/newSubmissionHandler.ts
+++ b/src/routers/handlers/new-submission/newSubmissionHandler.ts
@@ -1,0 +1,73 @@
+import {Request, Response} from "express";
+import {Transaction} from "@companieshouse/api-sdk-node/dist/services/transaction/types";
+import {ApiErrorResponse, Resource} from "@companieshouse/api-sdk-node/dist/services/resource";
+import {postTransaction} from "../../../services/transactionService";
+import {createPscExtension, PscExtensions, PscExtensionsData} from "../../../services/pscExtensionsService";
+import {logger} from "../../../lib/logger";
+
+export class NewSubmissionHandler {
+
+    // todo(1): implement this fully with the web app, when submitting an extension request
+    public async handleNewSubmission(req: Request, res: Response): Promise<string> {
+        const transaction: Transaction = await postTransaction(req);
+        logger.info(`CREATED transaction with transactionId="${transaction.id}"`);
+
+        // todo(2): ensure we have server side validation to not allow MORE than 2 verification requests
+        const resource = await this.createNewSubmission(req, transaction);
+
+        const companyNumber = req.query.companyNumber as string;
+
+        let nextPageUrl: string = "";
+        if (this.isErrorResponse(resource)) {
+            // todo(any): proper error page i.e extensions already submitted/can't submit more
+            // todo(any): 500, server error or something went wrong page if server error?
+            nextPageUrl = "/extensions/problem-with-psc-data";
+        } else {
+            const pscExtension = resource.resource;
+            logger.info(`CREATED New Resource ${pscExtension?.links?.self}`);
+
+            // todo(any): route to generic extension successful page, or have a page per extension req?
+            // page per extension req might be better for tracking etc, but generic one is "simpler"
+            // psuedo-code atm below, will need to be worked on and integrated with front-end
+            const regex = "persons-with-significant-control-extensions/(.*)$";
+            const resourceId = pscExtension?.links?.self?.match(regex);
+            nextPageUrl = `/extensions/confirmation/${transaction.id}/${resourceId?.[1]}`;
+        }
+
+        // do we even need company number here? or can do it just on the transaction id and resource?
+        return `${nextPageUrl}?companyNumber=${companyNumber}`;
+    }
+
+    public async createNewSubmission(request: Request, transaction: Transaction): Promise<Resource<PscExtensions> | ApiErrorResponse> {
+        // are these accurate? we need to make sure we have these query params and body.
+        const companyNumber = request.query.companyNumber as string;
+        const pscNotificationId = request.query.selectedPscId as string;
+
+        // todo(any): better enums/keys for extension reasons
+        // psc-extensions-web/src/views/router_views/reason-for-extension.njk:25
+        // can we use more sensible mappings i.e
+        // rather than:
+        //   - reason_for_extension_1
+        //   - reason_for_extension_2
+        // we could have:
+        //   - applied-for-identity-documents-but-not-received-yet
+        //   - arranged-through-govuk-one-login-to-verify-at-post-office
+        // these mappings would need updated in translations and chips.
+        const extensionReason = request.body.extensionReason as string;
+
+        const extensionData: PscExtensionsData = {
+            companyNumber,
+            pscNotificationId,
+            extensionDetails: {
+                extensionReason,
+                extensionRequestDate: new Date().toISOString()
+            }
+        };
+
+        return createPscExtension(request, transaction, extensionData);
+    }
+
+    public isErrorResponse(obj: any): obj is ApiErrorResponse {
+        return obj.httpStatusCode >= 400;
+    }
+}

--- a/src/services/companyProfileService.ts
+++ b/src/services/companyProfileService.ts
@@ -1,0 +1,18 @@
+import {Request} from "express";
+import {CompanyProfile} from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import {createOAuthApiClient} from "../lib/utils/api.client";
+import {logger} from "../lib/logger";
+
+export const getCompanyProfile = async (req: Request, companyNumber: string): Promise<CompanyProfile> => {
+    const oAuthApiClient = createOAuthApiClient(req.session);
+
+    logger.debug(`Getting company profile for companyNumber="${companyNumber}"`);
+
+    const response = await oAuthApiClient.companyProfile.getCompanyProfile(companyNumber);
+
+    if (!response.resource) {
+        throw new Error(`No company profile found for companyNumber="${companyNumber}"`);
+    }
+
+    return response.resource;
+};

--- a/src/services/pscExtensionsService.ts
+++ b/src/services/pscExtensionsService.ts
@@ -1,0 +1,90 @@
+import {Request} from "express";
+import {Transaction} from "@companieshouse/api-sdk-node/dist/services/transaction/types";
+import {ApiErrorResponse, Resource} from "@companieshouse/api-sdk-node/dist/services/resource";
+import {HttpStatusCode} from "axios";
+import {createOAuthApiClient} from "../lib/utils/api.client";
+import {logger} from "../lib/logger";
+
+// todo: move this to sdk?
+export interface PscExtensionsData {
+    companyNumber: string;
+    pscNotificationId: string;
+    relevantOfficer?: {
+        dateOfBirth?: string;
+        nameElements?: {
+            title?: string;
+            forename?: string;
+            surname?: string;
+        };
+    };
+    extensionDetails: {
+        extensionReason: string;
+        extensionRequestDate?: string;
+    };
+}
+
+export interface PscExtensions {
+    id?: string;
+    links?: {
+        self?: string;
+        validationStatus?: string;
+    };
+    data?: PscExtensionsData;
+}
+
+export const createPscExtension = async (request: Request, transaction: Transaction, extensionData: PscExtensionsData): Promise<Resource<PscExtensions> | ApiErrorResponse> => {
+    if (!extensionData) {
+        throw new Error(`Aborting: PscExtensionsData is required for PSC Extension POST request for transactionId="${transaction.id}"`);
+    }
+    if (!extensionData.companyNumber) {
+        throw new Error(`Aborting: companyNumber is required for PSC Extension POST request for transactionId="${transaction.id}"`);
+    }
+    if (!extensionData.pscNotificationId) {
+        throw new Error(`Aborting: pscNotificationId is required for PSC Extension POST request for transactionId="${transaction.id}"`);
+    }
+
+    const oAuthApiClient = createOAuthApiClient(request.session);
+
+    logger.debug(`Creating PSC extension resource for transactionId="${transaction.id}": ${transaction.description}`);
+
+    const headers = extractRequestIdHeader(request);
+
+    // todo(3): change this to use api-sdk-node or private-api-sdk-node, we should add our psc-extensions-api
+    //  schema to api.ch.gov.uk-specifications or private.api.ch.gov.uk-specifications and then make an sdk.
+    const url = `/transactions/${transaction.id}/persons-with-significant-control-extensions`;
+
+    try {
+        // todo(any): this is psuedo, actually use the sdk and call the psc-extensions-api
+        //  this goes to psc-extensions-api's uk.gov.companieshouse.psc.extensions.api.controller.impl.PscExtensionsControllerImpl#createPscExtension
+        const response = await oAuthApiClient.httpPost(url, extensionData, headers);
+
+        if (!response) {
+            throw new Error(`PSC Extension POST request returned no response for transactionId="${transaction.id}"`);
+        }
+
+        if (response.status === HttpStatusCode.InternalServerError) {
+            logger.error(`Internal server error when creating PSC extension for transactionId="${transaction.id}"`);
+            throw new Error(`Internal server error when creating PSC extension for transactionId="${transaction.id}"`);
+        }
+
+        if (!response.status || response.status !== HttpStatusCode.Created) {
+            throw new Error(`Failed to POST PSC Extension for transactionId="${transaction.id}", status: ${response.status}`);
+        }
+
+        logger.debug(`POST PSC Extension finished with status ${response.status} for transactionId="${transaction.id}"`);
+
+        return {
+            httpStatusCode: response.status,
+            resource: response.body
+        } as Resource<PscExtensions>;
+
+    } catch (error) {
+        logger.error(`Error creating PSC extension for transactionId="${transaction.id}": ${error}`);
+        throw error;
+    }
+};
+
+const extractRequestIdHeader = (request: Request): { [key: string]: string } => {
+    const requestId = request.headers["x-request-id"] as string;
+    return requestId ? {"x-request-id": requestId} : {};
+};

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -1,0 +1,46 @@
+import {Request} from "express";
+import {Transaction} from "@companieshouse/api-sdk-node/dist/services/transaction/types";
+import {CompanyProfile} from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import {ApiErrorResponse, Resource} from "@companieshouse/api-sdk-node/dist/services/resource";
+import {HttpStatusCode} from "axios";
+import {createOAuthApiClient} from "../lib/utils/api.client";
+import {getCompanyProfile} from "./companyProfileService";
+import {logger} from "../lib/logger";
+
+const REFERENCE = "PSC_EXTENSION";
+const DESCRIPTION = "PSC extension request";
+
+export const postTransaction = async (req: Request): Promise<Transaction> => {
+    const companyNumber = req.query.companyNumber as string;
+    const companyProfile: CompanyProfile = await getCompanyProfile(req, companyNumber);
+    const companyName: string = companyProfile.companyName;
+    const oAuthApiClient = createOAuthApiClient(req.session);
+
+    const transaction: Transaction = {
+        reference: REFERENCE,
+        description: DESCRIPTION,
+        companyName
+    };
+
+    logger.debug(`Creating transaction with companyNumber="${companyNumber}"`);
+    const requestId = req.headers["x-request-id"] as string | undefined;
+    const sdkResponse: Resource<Transaction> | ApiErrorResponse = await oAuthApiClient.transaction.postTransaction(transaction, requestId);
+
+    if (!sdkResponse) {
+        return Promise.reject(new Error(`No response from Transaction API for companyNumber="${companyNumber}"`));
+    }
+
+    if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= HttpStatusCode.BadRequest) {
+        return Promise.reject(new Error(`HTTP status code ${sdkResponse.httpStatusCode} - Failed to post transaction with companyNumber="${companyNumber}"`));
+    }
+
+    const castedSdkResponse: Resource<Transaction> = sdkResponse as Resource<Transaction>;
+
+    if (!castedSdkResponse.resource) {
+        return Promise.reject(new Error(`No resource in Transaction API response for companyNumber="${companyNumber}"`));
+    }
+
+    logger.debug(`Received transaction with status code ${sdkResponse.httpStatusCode} for companyNumber="${companyNumber}"`);
+
+    return Promise.resolve(castedSdkResponse.resource);
+};


### PR DESCRIPTION
**Jira ticket**: 

- https://companieshouse.atlassian.net/browse/DEEP-367
- https://companieshouse.atlassian.net/browse/DEEP-362

## Brief description of the change(s)

- Updated PscExtensionsService to use pscNotificationId for consistency with verification
- Modified transaction and extension creation flow to match psc-verification-web pattern
- Integrated with psc-extensions-api POST endpoint for transaction-based submissions
- Added proper data transformation from web UI to API format
- Supports 6 extension reasons from reason-for-extension.json UI configuration
- Ready for integration with complete psc-extensions-api and chips backend flow

## Checklist

- [ ] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [ ] Written tests.
- [ ] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

