### PR TITLE
💄 Deep-537- BAU: New welsh text in footer

### DIFF
--- a/locales/cy/layout.json
+++ b/locales/cy/layout.json
@@ -6,15 +6,15 @@
   "phase_banner_help_improve": " yn ein helpu i'w wella.",
   "phase_banner_tag": "Adipiscing",
 
-  "footer_policies": "Lorem",
-  "footer_cookies": "Consectetur",
-  "footer_contact_us": "Iaculis suscipit",
-  "footer_developers": "Proin",
-  "footer_accessibility_statement": "Efficitur ipsum",
+  "footer_policies": "Polisïau",
+  "footer_cookies": "Cwcis",
+  "footer_contact_us": "Cysylltu â ni",
+  "footer_developers": "Datblygwyr",
+  "footer_accessibility_statement": "Datganiad hygyrchedd",
 
   "global_footer_ogl_v3": "Drwydded Llywodraeth Agored v3.0",
   "global_footer_ogl_v3_url": "https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/",
-  "global_footer_licence_p1": "Mae'r holl gynnwys ar gael o dan y ",
+  "global_footer_licence_p1": "Mae'r holl gynnwys ar gael o dan",
   "global_footer_licence_p2": ", ac eithrio lle nodir yn wahanol",
   "global_footer_crown_copyright": "© Hawlfraint y Goron"
 }

--- a/test/src/components.test.ts
+++ b/test/src/components.test.ts
@@ -46,11 +46,11 @@ describe("GET extension info router and retrieve components such as footer links
         const $ = cheerio.load(resp.text);
 
         const expectedLinks = [
-            { href: "https://resources.companieshouse.gov.uk/serviceInformation.shtml", text: "Lorem" },
-            { href: "http://chsurl.co/help/cookies", text: "Consectetur" },
-            { href: "https://www.gov.uk/government/organisations/companies-house#org-contacts", text: "Iaculis suscipit" },
-            { href: "https://developer.company-information.service.gov.uk/", text: "Proin" },
-            { href: "http://chsurl.co/help/accessibility-statement", text: "Efficitur ipsum" }
+            { href: "https://resources.companieshouse.gov.uk/serviceInformation.shtml", text: "Polisïau" },
+            { href: "http://chsurl.co/help/cookies", text: "Cwcis" },
+            { href: "https://www.gov.uk/government/organisations/companies-house#org-contacts", text: "Cysylltu â ni" },
+            { href: "https://developer.company-information.service.gov.uk/", text: "Datblygwyr" },
+            { href: "http://chsurl.co/help/accessibility-statement", text: "Datganiad hygyrchedd" }
         ];
 
         const footerLinks = $(".govuk-footer__inline-list-item a");


### PR DESCRIPTION
**Jira ticket**: 
https://companieshouse.atlassian.net/browse/DEEP-537

## Brief description of the change(s)

Updating welsh translations in the footer.

## Working example
**Before:**
<img width="1102" height="356" alt="Screenshot 2025-09-18 at 14 25 28" src="https://github.com/user-attachments/assets/70fd5f1c-74e2-48d7-8374-6dae166b03a4" />


**After:**
<img width="1102" height="356" alt="Screenshot 2025-09-18 at 14 34 03" src="https://github.com/user-attachments/assets/acd70a79-c438-4aec-b9c2-664305540c08" />


## Test notes

 Usual method.

